### PR TITLE
Fix heredoc single double no quote issue 

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -85,13 +85,11 @@ typedef enum e_exec_context
 int								collect_all_heredocs(t_ast *root,
 									t_shell_context *sh_ctx);
 
-int								read_heredoc_lines(int fd,
+int								read_heredoc_lines(int tmp_file_des,
 									const char *delimiter,
-									t_shell_context *sh_ctx);
-// char							*heredoc_delimiter_strip(const char *raw,
-// 									bool *quoted, t_shell_context *sh_ctx);
+									t_shell_context *sh_ctx, bool is_quoted);
 char							*heredoc_delimiter_strip(const char *raw,
-									bool *quoted);
+									bool *quoted, t_shell_context *sh_ctx);
 
 // executor
 int								execute(t_ast *node,


### PR DESCRIPTION
previously delimiter lim'' -> lim ''
lim'->lim'

currently:  
1. added is_quoted flag;
2. handle unclosed quote as error message
3. handle \ as normal charactors 
4. test pased execept 

cat << hello
$USER
$NOVAR
$HOME
hello
<img width="867" height="342" alt="image" src="https://github.com/user-attachments/assets/ae5dc7bb-d555-4ec6-a61e-da92efb458e3" />

