### PR TITLE
fix pwd failed stdout

### DIFF
--- a/src/builtins/builtin_cmds.c
+++ b/src/builtins/builtin_cmds.c
@@ -248,7 +248,7 @@ int	builtin_pwd(char **argv, t_shell_context *ctx)
 	pwd = getcwd(NULL, 0);
 	if (!pwd)
 		return (print_errno_n_return(1, "pwd", NULL, errno));
-	ft_putendl_fd(pwd, STDERR_FILENO);
+	ft_putendl_fd(pwd, STDOUT_FILENO);
 	free(pwd);
 	return (0);
 }


### PR DESCRIPTION

previous fail in STD_OUT 

pwd

cd $HOME
pwd

pwd pwd

pwd hello


reason:
file descriptor is wrong m should be STDOUT_FILENO: 
ft_putendl_fd(pwd, STDERR_FILENO); 
