### PR TITLE
try ./cmd when PATH is unset

### DIFF
--- a/src/execution/exec_command.c
+++ b/src/execution/exec_command.c
@@ -107,7 +107,10 @@ char	*resolve_cmd_path(char *cmd, t_shell_context *sh_ctx)
 		env = env->next;
 	}
 	if (!path_ptr)
-		return (NULL);
+	{ // try ./cmd
+		full_path = ft_strjoin("./", cmd);
+		return (full_path);
+	}
 	if (*path_ptr == '\0')
 		// return (print_msg_n_return(127, cmd, NULL,
 		//	"No such file or directory"));


### PR DESCRIPTION
#14 

when path is unset, there is no PATH in the env, so resolve_cmd_path returns NULL.
While bash actually still tried "./cmd", now adding this logic 