### PR TITLE
fix export exit_code for invalid options

### DIFF
--- a/src/builtins/builtin_cmds.c
+++ b/src/builtins/builtin_cmds.c
@@ -73,10 +73,11 @@ int	builtin_export(char **argv, t_shell_context *ctx)
 	int		i;
 	int		status;
 	char	*arg;
-	char	*eq;
+	char	*equal_sign_loc;
 	char	*name;
 	char	*val;
 	char	*plus_eq;
+	int		j;
 
 	i = 1;
 	status = 0;
@@ -85,20 +86,32 @@ int	builtin_export(char **argv, t_shell_context *ctx)
 		print_env(true, ctx);
 		return (0);
 	}
-	while (argv[i])
+	while (argv[i]) // check each if --test=100
 	{
 		arg = argv[i];
-		eq = ft_strchr(arg, '=');
+		// check - valid options
+		if (arg[0] == '-')
+		{
+			j = 1;
+			while (arg[j])
+			{
+				if (arg[j] != 'f' || arg[j] != 'n' || arg[j] != 'p')
+					return (print_msg_n_return(2, "export", arg,
+							"invalid option"));
+				j++;
+			}
+		}
+		equal_sign_loc = ft_strchr(arg, '=');
 		/* Detect NAME+=VALUE safely:
 			only when there is an '=' and the char right before '=' is '+' */
 		plus_eq = NULL;
-		if (eq && eq > arg && eq[-1] == '+')
-			plus_eq = eq - 1;
+		if (equal_sign_loc && equal_sign_loc > arg && equal_sign_loc[-1] == '+')
+			plus_eq = equal_sign_loc - 1;
 		if (plus_eq)
 		{
 			/* NAME+=VALUE */
 			name = ft_substr(arg, 0, (size_t)(plus_eq - arg));
-			val = eq + 1; /* value starts after '=' */
+			val = equal_sign_loc + 1; /* value starts after '=' */
 			if (!name || !is_valid_ident(name))
 			{
 				print_msg_n_return(1, "export", arg, "not a valid identifier");
@@ -111,11 +124,11 @@ int	builtin_export(char **argv, t_shell_context *ctx)
 			}
 			free(name);
 		}
-		else if (eq)
+		else if (equal_sign_loc)
 		{
 			/* NAME=VALUE */
-			name = ft_substr(arg, 0, (size_t)(eq - arg));
-			val = eq + 1;
+			name = ft_substr(arg, 0, (size_t)(equal_sign_loc - arg));
+			val = equal_sign_loc + 1;
 			if (!name || !is_valid_ident(name))
 			{
 				print_msg_n_return(1, "export", arg, "not a valid identifier");
@@ -179,7 +192,8 @@ int	builtin_exit(char **argv, t_shell_context *ctx)
 		/* Keep your previous behavior: return 1 (no exit). */
 		return (2);
 	}
-	/* too many args => error, DO NOT exit (matches common shell behavior) */
+	/* too many args => error,
+		DO NOT exit (matches common shell behavior) */
 	if (argv[2])
 		return (print_msg_n_return(1, "exit", NULL, "too many arguments"));
 	exit(ft_atoi(argv[1]));

--- a/src/env/env.c
+++ b/src/env/env.c
@@ -240,7 +240,7 @@ char	**build_envp_from_env_list(t_shell_context *sh_ctx)
 t_list	*init_env(char **envp, t_shell_context *sh_ctx)
 {
 	t_list	*env_list;
-	char	*equal_sign;
+	char	*equal_sign_loc;
 	char	*name_tmp;
 
 	env_list = NULL;
@@ -248,22 +248,23 @@ t_list	*init_env(char **envp, t_shell_context *sh_ctx)
 		return (NULL);
 	while (envp && *envp)
 	{
-		equal_sign = ft_strchr(*envp, '=');
-		if (!equal_sign)
+		equal_sign_loc = ft_strchr(*envp, '=');
+		// i think it already ensures it only searches for the 1st =
+		if (!equal_sign_loc) // no =
 		{
 			// No '=' -> name only, value NULL
 			// exported=true because it came from envp
 			add_new_env_var(&env_list, *envp, NULL, true, sh_ctx);
 		}
-		else
+		else // there is =
 		{
 			// name is left side
 			// TODO: maybe need ft_substr_s
-			name_tmp = ft_substr(*envp, 0, (size_t)(equal_sign - *envp));
+			name_tmp = ft_substr(*envp, 0, (size_t)(equal_sign_loc - *envp));
 			if (name_tmp)
 			{
 				// value is right side (eq+1)
-				add_new_env_var(&env_list, name_tmp, equal_sign + 1, true,
+				add_new_env_var(&env_list, name_tmp, equal_sign_loc + 1, true,
 					sh_ctx);
 				free(name_tmp);
 			}
@@ -271,8 +272,8 @@ t_list	*init_env(char **envp, t_shell_context *sh_ctx)
 		envp++;
 	}
 	sh_ctx->env = env_list;
-	// Recommendation: do NOT cache HOME here (avoids stale cache bugs)
-	// If you insist on caching:
+	// choose not to cache HOME here (avoids stale cache bugs)
+	// or  insist on caching:
 	// sh_ctx->home = env_get_value(env_list, "HOME");
 	if (!env_node_find(env_list, "PATH"))
 		add_new_env_var(&env_list, "PATH", DEFAULT_PATH, true, sh_ctx);

--- a/src/execution/exec_command.c
+++ b/src/execution/exec_command.c
@@ -191,6 +191,9 @@ int	execute_external(t_ast_command *cmd, t_shell_context *sh_ctx)
 		if (*cmd->args[0] == '\0')
 			return (print_msg_n_return(127, cmd->args[0], NULL,
 					"command not found"));
+		// if (ft_strcmp(cmd->args[0], "."))
+		// 	return (print_msg_n_return(2, cmd->args[0], NULL,
+		// 			"filename argument required"));
 		path = resolve_cmd_path(cmd->args[0], sh_ctx);
 		if (!path)
 			return (print_msg_n_return(127, cmd->args[0], NULL,


### PR DESCRIPTION
fixed exit code error of #31 

cause : 
invalid option should return 2 , nvalid identifier should return 1 

```
ylang@f4r1s14:~/code/minishell-github$ export -- test=122
ylang@f4r1s14:~/code/minishell-github$ export --test=122
bash: export: --: invalid option
```

solve:

added a check logic before check for = to check str start with - , only valid options are f , n p ,

now exit code is 2 instead of 1 
